### PR TITLE
feat: extend Sorbian translations

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -56,6 +56,7 @@ import MapContainer from './pages/MapContainer'
 import { getBottomRoutes, routes } from './routes/sidebar'
 import { config } from './config'
 import { InviteApi } from './api/inviteApi'
+import { t } from './i18n'
 
 const userApi = new UserApi()
 const inviteApi = new InviteApi(userApi)
@@ -249,7 +250,7 @@ function App() {
     return (
       <div className='tw:flex tw:items-center tw:justify-center tw:h-screen'>
         <div>
-          <p className='tw:text-xl tw:font-semibold'>This map does not exist</p>
+          <p className='tw:text-xl tw:font-semibold'>{t('mapDoesNotExist')}</p>
         </div>
       </div>
     )

--- a/app/src/ModalContent.tsx
+++ b/app/src/ModalContent.tsx
@@ -7,6 +7,7 @@ import { useEffect, useState } from 'react'
 import { TextView } from 'utopia-ui'
 
 import { config } from './config'
+import { t } from './i18n'
 
 interface ChapterProps {
   clickAction1: () => void
@@ -24,30 +25,28 @@ export function Welcome1({ clickAction1, map }: ChapterProps) {
               className='tw:btn tw:btn-primary tw:place-self-end tw:mt-4'
               onClick={() => clickAction1()}
             >
-              Close
+              {t('close')}
             </label>
           </div>
         </>
       ) : (
         <>
-          <h3 className='tw:font-bold tw:text-lg'>Welcome to {map?.name || 'Utopia Map'}</h3>
+          <h3 className='tw:font-bold tw:text-lg'>
+            {t('welcomeTitle', { map: map?.name || 'Utopia Map' })}
+          </h3>
           <img
             className='tw:float-right tw:w-32 tw:m-2'
             src={config.apiUrl + 'assets/' + map.logo}
           ></img>
-          <p className='tw:py-3'>
-            It is a tool for collaborative mapping to connect local initiatives, people and events.
-          </p>
-          <p className='tw:py-1'>
-            Join us and grow the network by adding projects and events to the map.
-          </p>
-          <p className='tw:py-1'>Create your personal profile and place it on the map.</p>
+          <p className='tw:py-3'>{t('welcomeText1')}</p>
+          <p className='tw:py-1'>{t('welcomeText2')}</p>
+          <p className='tw:py-1'>{t('welcomeText3')}</p>
           <div className='tw:grid'>
             <label
               className='tw:btn tw:btn-primary tw:place-self-end tw:mt-4'
               onClick={() => clickAction1()}
             >
-              Close
+              {t('close')}
             </label>
           </div>
         </>

--- a/app/src/i18n.ts
+++ b/app/src/i18n.ts
@@ -1,0 +1,32 @@
+/* eslint-disable security/detect-object-injection */
+import de from './locales/de.json'
+import dsb from './locales/dsb.json'
+import hsb from './locales/hsb.json'
+
+const resources: Record<string, Record<string, string>> = {
+  de,
+  dsb,
+  hsb,
+}
+
+const getBrowserLanguage = (): string => {
+  const lang = navigator.language.split('-')[0]
+  return Object.prototype.hasOwnProperty.call(resources, lang) ? lang : 'de'
+}
+
+const currentLanguage = getBrowserLanguage()
+
+document.documentElement.lang = currentLanguage
+
+export const t = (key: string, params: Record<string, string> = {}): string => {
+  const langResources = Object.prototype.hasOwnProperty.call(resources, currentLanguage)
+    ? resources[currentLanguage]
+    : resources.de
+  let text = Object.prototype.hasOwnProperty.call(langResources, key) ? langResources[key] : key
+  for (const [k, v] of Object.entries(params)) {
+    text = text.replace(`{${k}}`, v)
+  }
+  return text
+}
+
+export default currentLanguage

--- a/app/src/locales/de.json
+++ b/app/src/locales/de.json
@@ -1,0 +1,15 @@
+{
+  "mapDoesNotExist": "Diese Karte existiert nicht",
+  "offersAndNeeds": "Angebote & Gesuche",
+  "offers": "Angebote",
+  "needs": "Gesuche",
+  "enterOffers": "Gib deine Angebote ein",
+  "enterNeeds": "Gib deine Gesuche ein",
+  "welcomeTitle": "Willkommen bei {map}",
+  "welcomeText1": "Dies ist ein Werkzeug für kollaboratives Mapping, um lokale Initiativen, Menschen und Veranstaltungen zu verbinden.",
+  "welcomeText2": "Mach mit und erweitere das Netzwerk, indem du Projekte und Veranstaltungen zur Karte hinzufügst.",
+  "welcomeText3": "Erstelle dein persönliches Profil und platziere es auf der Karte.",
+  "close": "Schließen",
+  "layerLoading": "lade {layer} ...",
+  "layerLoaded": "{layer} geladen"
+}

--- a/app/src/locales/dsb.json
+++ b/app/src/locales/dsb.json
@@ -1,0 +1,15 @@
+{
+  "mapDoesNotExist": "Toś ta mapa njeeksistěrujo",
+  "offersAndNeeds": "Nabidki a potrjeby",
+  "offers": "Nabidki",
+  "needs": "Potrjeby",
+  "enterOffers": "Zapódajśo swóje nabidki",
+  "enterNeeds": "Zapódajśo swóje potrjeby",
+  "welcomeTitle": "Witajśo k {map}",
+  "welcomeText1": "To jo rěd za zgromadne kartěrowanje, aby lokalne iniciatiwy, luźi a tšojenja zwězał.",
+  "welcomeText2": "Pśidrużćo se a pówětšćo seś, pśidawajśo projekty a tšojenja ku karśe.",
+  "welcomeText3": "Napórajśo swójo wósobinske profil a placěrujśo jen na karśe.",
+  "close": "Zacyniś",
+  "layerLoading": "{layer} se zacytujo ...",
+  "layerLoaded": "{layer} zacytany"
+}

--- a/app/src/locales/hsb.json
+++ b/app/src/locales/hsb.json
@@ -1,0 +1,15 @@
+{
+  "mapDoesNotExist": "Tuta mapa njeeksistuje",
+  "offersAndNeeds": "Nabidki a potrjeby",
+  "offers": "Nabidki",
+  "needs": "Potrjeby",
+  "enterOffers": "Zapodajće swoje nabidki",
+  "enterNeeds": "Zapodajće swoje potrjeby",
+  "welcomeTitle": "Witajće k {map}",
+  "welcomeText1": "Je to nastroj za zhromadne kartěrowanje, zo by lokalne iniciatiwy, ludźi a podawki zwjazał.",
+  "welcomeText2": "Přidružće so a powjetšće syć, přidawajće projekty a podawki na kartu.",
+  "welcomeText3": "Wutworće swój wosobinski profil a stajće jón na kartu.",
+  "close": "Začinić",
+  "layerLoading": "{layer} so začituje ...",
+  "layerLoaded": "{layer} je so začitał"
+}

--- a/lib/src/Components/Map/hooks/useItems.tsx
+++ b/lib/src/Components/Map/hooks/useItems.tsx
@@ -8,6 +8,8 @@
 import { useCallback, useReducer, createContext, useContext, useState } from 'react'
 import { toast } from 'react-toastify'
 
+import { t } from '#src/i18n'
+
 import { useAddLayer } from './useLayers'
 
 import type { Item } from '#types/Item'
@@ -73,8 +75,8 @@ function useItemsManager(initialItems: Item[]): {
   const setItemsApi = useCallback(async (layer: LayerProps) => {
     addLayer(layer)
     const result = await toast.promise(layer.api!.getItems(), {
-      pending: `loading ${layer.name} ...`,
-      success: `${layer.name} loaded`,
+      pending: t('layerLoading', { layer: layer.name }),
+      success: t('layerLoaded', { layer: layer.name }),
       error: {
         render({ data }) {
           return `${data}`

--- a/lib/src/Components/Profile/Templates/TabsForm.tsx
+++ b/lib/src/Components/Profile/Templates/TabsForm.tsx
@@ -15,6 +15,7 @@ import { ActionButton } from '#components/Profile/Subcomponents/ActionsButton'
 import { LinkedItemsHeaderView } from '#components/Profile/Subcomponents/LinkedItemsHeaderView'
 import { TagsWidget } from '#components/Profile/Subcomponents/TagsWidget'
 import { Tabs } from '#components/Templates/Tabs'
+import { t } from '#src/i18n'
 
 export const TabsForm = ({
   item,
@@ -89,7 +90,7 @@ export const TabsForm = ({
             ),
           },
           {
-            title: 'Offers & Needs',
+            title: t('offersAndNeeds'),
             component: (
               <div className='tw:h-full'>
                 <div className='tw:w-full tw:h-[calc(50%-0.75em)] tw:mb-4'>
@@ -101,7 +102,7 @@ export const TabsForm = ({
                         offers: v,
                       }))
                     }
-                    placeholder='enter your offers'
+                    placeholder={t('enterOffers')}
                     containerStyle='tw:bg-transparent tw:w-full tw:h-full tw:mt-3 tw:text-xs tw:h-[calc(100%-1rem)] tw:min-h-[5em] tw:pb-2 tw:overflow-auto'
                   />
                 </div>
@@ -114,7 +115,7 @@ export const TabsForm = ({
                         needs: v,
                       }))
                     }
-                    placeholder='enter your needs'
+                    placeholder={t('enterNeeds')}
                     containerStyle='tw:bg-transparent tw:w-full tw:h-full tw:mt-3 tw:text-xs tw:h-[calc(100%-1rem)] tw:min-h-[5em] tw:pb-2 tw:overflow-auto'
                   />
                 </div>

--- a/lib/src/Components/Profile/Templates/TabsView.tsx
+++ b/lib/src/Components/Profile/Templates/TabsView.tsx
@@ -16,6 +16,7 @@ import { StartEndView, TextView } from '#components/Map/Subcomponents/ItemPopupC
 import { ActionButton } from '#components/Profile/Subcomponents/ActionsButton'
 import { LinkedItemsHeaderView } from '#components/Profile/Subcomponents/LinkedItemsHeaderView'
 import { TagView } from '#components/Templates/TagView'
+import { t } from '#src/i18n'
 import { timeAgo } from '#utils/TimeAgo'
 
 import type { Item } from '#types/Item'
@@ -198,7 +199,11 @@ export const TabsView = ({
             name='my_tabs_2'
             role='tab'
             className={`tw:tab tw:font-bold tw:ps-2! tw:pe-2! ${!(item.layer.itemType.icon_as_labels && activeTab !== 1) && 'tw:min-w-[10.4em]'} `}
-            aria-label={`${item.layer.itemType.icon_as_labels && activeTab !== 1 ? '♻️' : '♻️\u00A0Offers & Needs'}`}
+            aria-label={`${
+              item.layer.itemType.icon_as_labels && activeTab !== 1
+                ? '♻️'
+                : `♻️\u00A0${t('offersAndNeeds')}`
+            }`}
             checked={activeTab === 1 && true}
             onChange={() => updateActiveTab(1)}
           />
@@ -210,7 +215,7 @@ export const TabsView = ({
               <div className='tw:grid tw:grid-cols-1'>
                 {offers.length > 0 ? (
                   <div className='tw:col-span-1'>
-                    <h3 className='tw:-mb-2'>Offers</h3>
+                    <h3 className='tw:-mb-2'>{t('offers')}</h3>
                     <div className='tw:flex tw:flex-wrap tw:mb-4'>
                       {offers.map((o) => (
                         <TagView
@@ -228,7 +233,7 @@ export const TabsView = ({
                 )}
                 {needs.length > 0 ? (
                   <div className='tw:col-span-1'>
-                    <h3 className='tw:-mb-2 tw:col-span-1'>Needs</h3>
+                    <h3 className='tw:-mb-2 tw:col-span-1'>{t('needs')}</h3>
                     <div className='tw:flex tw:flex-wrap  tw:mb-4'>
                       {needs.map((n) => (
                         <TagView key={n.id} tag={n} onClick={() => addFilterTag(n)} />

--- a/lib/src/i18n.ts
+++ b/lib/src/i18n.ts
@@ -1,0 +1,32 @@
+/* eslint-disable security/detect-object-injection */
+import de from './locales/de.json'
+import dsb from './locales/dsb.json'
+import hsb from './locales/hsb.json'
+
+const resources: Record<string, Record<string, string>> = {
+  de: de as Record<string, string>,
+  dsb: dsb as Record<string, string>,
+  hsb: hsb as Record<string, string>,
+}
+
+const getBrowserLanguage = (): string => {
+  const lang = navigator.language.split('-')[0]
+  return Object.prototype.hasOwnProperty.call(resources, lang) ? lang : 'de'
+}
+
+const currentLanguage = getBrowserLanguage()
+
+document.documentElement.lang = currentLanguage
+
+export const t = (key: string, params: Record<string, string> = {}): string => {
+  const langResources = Object.prototype.hasOwnProperty.call(resources, currentLanguage)
+    ? resources[currentLanguage]
+    : resources.de
+  let text = Object.prototype.hasOwnProperty.call(langResources, key) ? langResources[key] : key
+  for (const [k, v] of Object.entries(params)) {
+    text = text.replace(`{${k}}`, v)
+  }
+  return text
+}
+
+export default currentLanguage

--- a/lib/src/locales/de.json
+++ b/lib/src/locales/de.json
@@ -1,0 +1,16 @@
+{
+  "mapDoesNotExist": "Diese Karte existiert nicht",
+  "offersAndNeeds": "Angebote & Gesuche",
+  "offers": "Angebote",
+  "needs": "Gesuche",
+  "enterOffers": "Gib deine Angebote ein",
+  "enterNeeds": "Gib deine Gesuche ein",
+  "welcomeTitle": "Willkommen bei {map}",
+  "welcomeText1": "Dies ist ein Werkzeug für kollaboratives Mapping, um lokale Initiativen, Menschen und Veranstaltungen zu verbinden.",
+  "welcomeText2": "Mach mit und erweitere das Netzwerk, indem du Projekte und Veranstaltungen zur Karte hinzufügst.",
+  "welcomeText3": "Erstelle dein persönliches Profil und platziere es auf der Karte.",
+  "close": "Schließen",
+  "layerLoading": "lade {layer} ...",
+  "layerLoaded": "{layer} geladen"
+}
+

--- a/lib/src/locales/dsb.json
+++ b/lib/src/locales/dsb.json
@@ -1,0 +1,16 @@
+{
+  "mapDoesNotExist": "Toś ta mapa njeeksistěrujo",
+  "offersAndNeeds": "Nabidki a potrjeby",
+  "offers": "Nabidki",
+  "needs": "Potrjeby",
+  "enterOffers": "Zapódajśo swóje nabidki",
+  "enterNeeds": "Zapódajśo swóje potrjeby",
+  "welcomeTitle": "Witajśo k {map}",
+  "welcomeText1": "To jo rěd za zgromadne kartěrowanje, aby lokalne iniciatiwy, luźi a tšojenja zwězał.",
+  "welcomeText2": "Pśidrużćo se a pówětšćo seś, pśidawajśo projekty a tšojenja ku karśe.",
+  "welcomeText3": "Napórajśo swójo wósobinske profil a placěrujśo jen na karśe.",
+  "close": "Zacyniś",
+  "layerLoading": "{layer} se zacytujo ...",
+  "layerLoaded": "{layer} zacytany"
+}
+

--- a/lib/src/locales/hsb.json
+++ b/lib/src/locales/hsb.json
@@ -1,0 +1,16 @@
+{
+  "mapDoesNotExist": "Tuta mapa njeeksistuje",
+  "offersAndNeeds": "Nabidki a potrjeby",
+  "offers": "Nabidki",
+  "needs": "Potrjeby",
+  "enterOffers": "Zapodajće swoje nabidki",
+  "enterNeeds": "Zapodajće swoje potrjeby",
+  "welcomeTitle": "Witajće k {map}",
+  "welcomeText1": "Je to nastroj za zhromadne kartěrowanje, zo by lokalne iniciatiwy, ludźi a podawki zwjazał.",
+  "welcomeText2": "Přidružće so a powjetšće syć, přidawajće projekty a podawki na kartu.",
+  "welcomeText3": "Wutworće swój wosobinski profil a stajće jón na kartu.",
+  "close": "Začinić",
+  "layerLoading": "{layer} so začituje ...",
+  "layerLoaded": "{layer} je so začitał"
+}
+


### PR DESCRIPTION
## Summary
- translate Offers & Needs tabs
- localize welcome dialog and layer loading messages
- add interpolation support to i18n helper

## Testing
- `npm run test:lint:eslint` (app)
- `npx eslint src/i18n.ts src/Components/Map/hooks/useItems.tsx src/Components/Profile/Templates/TabsView.tsx src/Components/Profile/Templates/TabsForm.tsx` (lib)


------
https://chatgpt.com/codex/tasks/task_e_68b704ca49dc832c8db293e24fa1c4a8